### PR TITLE
Allow special index pages in toctree

### DIFF
--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -118,26 +118,36 @@ class TocTree(SphinxDirective):
                 docname = docname_join(self.env.docname, docname)
                 if url_re.match(ref) or ref == 'self':
                     toctree['entries'].append((title, ref))
-                elif docname not in self.env.found_docs:
-                    if excluded(self.env.doc2path(docname, False)):
-                        message = __('toctree contains reference to excluded document %r')
-                        subtype = 'excluded'
-                    else:
-                        message = __('toctree contains reference to nonexisting document %r')
-                        subtype = 'not_readable'
-
-                    logger.warning(message, docname, type='toc', subtype=subtype,
-                                   location=toctree)
-                    self.env.note_reread()
                 else:
-                    if docname in all_docnames:
-                        all_docnames.remove(docname)
-                    else:
-                        logger.warning(__('duplicated entry found in toctree: %s'), docname,
-                                       location=toctree)
+                    special_docs = {
+                        'genindex': 'genindex',
+                        'modindex': 'py-modindex',
+                        'py-modindex': 'py-modindex',
+                        'search': 'search',
+                    }
+                    target = special_docs.get(docname)
+                    if target:
+                        toctree['entries'].append((title, target))
+                    elif docname not in self.env.found_docs:
+                        if excluded(self.env.doc2path(docname, False)):
+                            message = __('toctree contains reference to excluded document %r')
+                            subtype = 'excluded'
+                        else:
+                            message = __('toctree contains reference to nonexisting document %r')
+                            subtype = 'not_readable'
 
-                    toctree['entries'].append((title, docname))
-                    toctree['includefiles'].append(docname)
+                        logger.warning(message, docname, type='toc', subtype=subtype,
+                                       location=toctree)
+                        self.env.note_reread()
+                    else:
+                        if docname in all_docnames:
+                            all_docnames.remove(docname)
+                        else:
+                            logger.warning(__('duplicated entry found in toctree: %s'), docname,
+                                           location=toctree)
+
+                        toctree['entries'].append((title, docname))
+                        toctree['includefiles'].append(docname)
 
         # entries contains all entries (self references, external links etc.)
         if 'reversed' in self.options:

--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -6,7 +6,7 @@ from docutils import nodes
 from docutils.nodes import Element, Node
 
 from sphinx import addnodes
-from sphinx.locale import __
+from sphinx.locale import _, __
 from sphinx.util import logging, url_re
 from sphinx.util.matching import Matcher
 from sphinx.util.nodes import clean_astext, process_only_nodes
@@ -139,6 +139,22 @@ class TocTree:
                         item = nodes.list_item('', para)
                         # don't show subitems
                         toc = nodes.bullet_list('', item)
+                    elif ref in {'genindex', 'modindex', 'py-modindex', 'search'}:
+                        ref = 'py-modindex' if ref == 'modindex' else ref
+                        if not title:
+                            titles = {
+                                'genindex': _('Index'),
+                                'py-modindex': _('Module Index'),
+                                'search': _('Search Page'),
+                            }
+                            title = titles.get(ref, ref)
+                        reference = nodes.reference('', '', internal=True,
+                                                    refuri=ref,
+                                                    anchorname='',
+                                                    *[nodes.Text(title)])
+                        para = addnodes.compact_paragraph('', '', reference)
+                        item = nodes.list_item('', para)
+                        toc = nodes.bullet_list('', item)
                     else:
                         if ref in parents:
                             logger.warning(__('circular toctree references '
@@ -165,14 +181,31 @@ class TocTree:
                                        ref, location=toctreenode)
                 except KeyError:
                     # this is raised if the included file does not exist
-                    if excluded(self.env.doc2path(ref, False)):
-                        message = __('toctree contains reference to excluded document %r')
-                    elif not included(self.env.doc2path(ref, False)):
-                        message = __('toctree contains reference to non-included document %r')
+                    if ref in {'genindex', 'modindex', 'py-modindex', 'search'}:
+                        ref = 'py-modindex' if ref == 'modindex' else ref
+                        if not title:
+                            titles = {
+                                'genindex': _('Index'),
+                                'py-modindex': _('Module Index'),
+                                'search': _('Search Page'),
+                            }
+                            title = titles.get(ref, ref)
+                        reference = nodes.reference('', '', internal=True,
+                                                    refuri=ref,
+                                                    anchorname='',
+                                                    *[nodes.Text(title)])
+                        para = addnodes.compact_paragraph('', '', reference)
+                        item = nodes.list_item('', para)
+                        toc = nodes.bullet_list('', item)
                     else:
-                        message = __('toctree contains reference to nonexisting document %r')
+                        if excluded(self.env.doc2path(ref, False)):
+                            message = __('toctree contains reference to excluded document %r')
+                        elif not included(self.env.doc2path(ref, False)):
+                            message = __('toctree contains reference to non-included document %r')
+                        else:
+                            message = __('toctree contains reference to nonexisting document %r')
 
-                    logger.warning(message, ref, location=toctreenode)
+                        logger.warning(message, ref, location=toctreenode)
                 else:
                     # if titles_only is given, only keep the main title and
                     # sub-toctrees

--- a/tests/roots/test-toctree-indexpages/conf.py
+++ b/tests/roots/test-toctree-indexpages/conf.py
@@ -1,0 +1,2 @@
+exclude_patterns = ['_build']
+templates_path = ['_templates']

--- a/tests/roots/test-toctree-indexpages/index.rst
+++ b/tests/roots/test-toctree-indexpages/index.rst
@@ -1,0 +1,12 @@
+.. Sphinx Tests documentation master file
+
+Welcome to index pages test
+===========================
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Indices
+
+   genindex
+   modindex
+   search

--- a/tests/test_toctree.py
+++ b/tests/test_toctree.py
@@ -37,3 +37,9 @@ def test_numbered_toctree(app, status, warning):
     index = re.sub(':numbered:.*', ':numbered: 1', index)
     (app.srcdir / 'index.rst').write_text(index, encoding='utf8')
     app.builder.build_all()
+
+
+@pytest.mark.sphinx(testroot='toctree-indexpages')
+def test_index_pages_in_toctree(app, status, warning):
+    app.builder.build_all()
+    assert 'nonexisting document' not in warning.getvalue()


### PR DESCRIPTION
## Summary
- avoid warnings when `genindex`, `modindex` or `search` appear in a toctree
- support these pages in the toctree processor
- add regression test

## Testing
- `pytest tests/test_toctree.py::test_index_pages_in_toctree -q`

------
https://chatgpt.com/codex/tasks/task_e_68516ad8b214832ab1f5341f6cbd7909